### PR TITLE
Add new reference table format and benchmarks for V100 & A100 GPUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ There is currently no absolute performance metric. For reference:
 |-----------------------------|----------------|----------------|----------------|
 | NVIDIA V100-SXM2-16GB HBM2  | ~14            | n/a            | n/a            |
 | NVIDIA V100-SXM2-32GB HBM2  | ~14            | n/a            | n/a            |
+| NVIDIA A100-PCIE-40GB HBM2  | ~106           | ~224           | n/a            |
 | NVIDIA A100-SXM4-80GB HBM2e | ~130           | ~270           | n/a            |
 | NVIDIA H100-SXM5-80GB HBM3  | ~373           | ~730           | ~1530          |
 | NVIDIA GH200 480GB HBM3e    | ~363           | ~705           | ~1660          |

--- a/README.md
+++ b/README.md
@@ -62,14 +62,15 @@ GPU fryer checks for homogeneous performance across all GPUs in the system (if m
 any performance degradation or thermal throttling.
 There is currently no absolute performance metric. For reference:
 
-| GPU                   | TFLOPS | Precision |
-|-----------------------|--------|-----------|
-| NVIDIA H100 80GB HBM3 | ~373   | FP32      |
-| NVIDIA H100 80GB HBM3 | ~730   | BF16      |
-| NVIDIA H100 80GB HBM3 | ~1530  | FP8       |
-| NVIDIA GH200 480GB    | ~363   | FP32      |
-| NVIDIA GH200 480GB    | ~705   | BF16      |
-| NVIDIA GH200 480GB    | ~1660  | FP8       |
+| GPU                         | FP32 (TFLOPS)  | BF16 (TFLOPS)  | FP8 (TFLOPS)   |
+|-----------------------------|----------------|----------------|----------------|
+| NVIDIA V100-SXM2-16GB HBM2  | ~14            | n/a            | n/a            |
+| NVIDIA V100-SXM2-32GB HBM2  | ~14            | n/a            | n/a            |
+| NVIDIA A100-SXM4-80GB HBM2e | ~130           | ~270           | n/a            |
+| NVIDIA H100-SXM5-80GB HBM3  | ~373           | ~730           | ~1530          |
+| NVIDIA GH200 480GB HBM3e    | ~363           | ~705           | ~1660          |
+
+
 
 ## Installation
 


### PR DESCRIPTION
This PR proposes the following:
* Revised the reference table format for improved clarity and extensibility.
* Added benchmark references for V100 and A100 GPUs.

Benchmark details:

-   Machine: [Jean Zay Supercomputer](http://www.idris.fr/eng/jean-zay/cpu/jean-zay-cpu-hw-eng.html) 🇫🇷
-   gpu-fryer version: master [2b6fb06](https://github.com/huggingface/gpu-fryer/commit/2b6fb06a6d38a8974e5058a663e26e8ee90618b6)
-   CUDA version: 12.8
-   Driver version: 570.86.15
-  3x10mins runs

Additionally, I ran gpu-fryer on Jean Zay H100-SXM5-80GB-HBM3, and observed similar TFLOPs performance, confirming consistency across runs.